### PR TITLE
hotfix: Add null and undefined checks in the 'map' method of the Just…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funcio",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Funcio is a powerful and versatile library designed to empower developers with the rich functionalities of functional programming within the JavaScript/TypeScript ecosystem. With Funcio, you can seamlessly incorporate the principles and techniques of functional programming into your codebase, unlocking a whole new world of possibilities.",
   "author": "Levi Prudêncio",
   "license": "MIT",

--- a/src/Monads/Maybe/just.ts
+++ b/src/Monads/Maybe/just.ts
@@ -58,8 +58,10 @@ export class Just<T> extends _Maybe {
    * @param {...function} fn - The function to apply to the value inside Just.
    * @returns {Just} A new Just with the result of applying the function.
    */
-  public map<R>(fn: (_: T) => R): Just<R> {
-    return Just.of(fn(this.value))
+  public map<R>(fn: (value: T) => R): Just<R> | Nothing<T> {
+    return _Maybe.fromNullable(this.value)
+      ? Just.of(fn(this.value))
+      : Nothing.of(this.value)
   }
 
   /**

--- a/test/maybe.spec.ts
+++ b/test/maybe.spec.ts
@@ -8,6 +8,18 @@ describe("Maybe Monad", () => {
     expect(container.isJust()).toBeTruthy()
   })
 
+
+  it("Should return 'Nothing' when mapping over an undefined value", async () => {
+    const container = _Maybe.of({ status: true, error: null })
+      .map(data => data.error)
+      .map(error => error.message)
+      .map(message => message);
+
+    expect(container.isNothing()).toBeTruthy();
+  });
+
+
+
   it("Should check if the returned value is a 'Nothing' container", async () => {
     const container = _Maybe.of(null)
     expect(container.isNothing()).toBeTruthy()
@@ -20,7 +32,7 @@ describe("Maybe Monad", () => {
   })
 
 
-  it("Should add two to the value inside a Maybe object and unwrap it",()=>{
+  it("Should add two to the value inside a Maybe object and unwrap it", () => {
     const addTwo = (value: number,) => value + 2
     const value = _Maybe.of(_Maybe.of(3).map(addTwo)).unwrap()
     expect(value).toBe(5)


### PR DESCRIPTION
… class